### PR TITLE
Fix parameter name -Password in example

### DIFF
--- a/Getting Started/Getting Started 2015 - Section 1.1 - Introduction.ps1
+++ b/Getting Started/Getting Started 2015 - Section 1.1 - Introduction.ps1
@@ -81,7 +81,7 @@ Part 2.1.2 - Connecting to SolidFire
 
 
 # Lab Group 1
-Connect-SFCluster -Target 192.168.0.100 -UserName <username> -ClearPassword <password>
+Connect-SFCluster -Target 192.168.0.100 -UserName <username> -Password <password>
 
 # Connect-SFCluster also supports stored credentials.
 


### PR DESCRIPTION
Section 1.1 script, Part 2.1.2 Example Connecting to SFCluster LabGroup 1 shows the parameter as "-ClearPassword and a value of <password>.
The parameter name is actually just "-Password" without the preceding word Clear.
